### PR TITLE
🐛 Remove queue properties

### DIFF
--- a/modules/storage/account/main.tf
+++ b/modules/storage/account/main.tf
@@ -20,14 +20,5 @@ resource "azurerm_storage_account" "account" {
     identity_ids = var.identity_ids
   }
 
-  queue_properties {
-    logging { # Sensitive
-      delete                = var.queue_loging_delete
-      read                  = var.queue_loging_read
-      write                 = var.queue_loging_write
-      version               = var.queue_loging_version
-      retention_policy_days = var.retention_policy_days
-    }
-  }
   tags = var.tags
 }

--- a/modules/storage/account/main.tf
+++ b/modules/storage/account/main.tf
@@ -20,5 +20,14 @@ resource "azurerm_storage_account" "account" {
     identity_ids = var.identity_ids
   }
 
+  queue_properties {
+    logging { # Sensitive
+      delete                = var.queue_loging_delete
+      read                  = var.queue_loging_read
+      write                 = var.queue_loging_write
+      version               = var.queue_loging_version
+      retention_policy_days = var.retention_policy_days
+    }
+  }
   tags = var.tags
 }

--- a/modules/storage/account/variables.tf
+++ b/modules/storage/account/variables.tf
@@ -46,10 +46,34 @@ variable "identity_ids" {
   default     = null
 }
 
+variable "queue_loging_delete" {
+  type        = bool
+  description = "Indicates whether all delete requests should be logged. Changing this forces a new resource. Default false"
+  default     = true
+}
+
+variable "queue_loging_read" {
+  type        = bool
+  description = "Indicates whether all read requests should be logged. Changing this forces a new resource. Default false"
+  default     = true
+}
+
+variable "queue_loging_write" {
+  type        = bool
+  description = "Indicates whether all write requests should be logged. Changing this forces a new resource. Default false"
+  default     = true
+}
+
+variable "queue_loging_version" {
+  type        = string
+  description = "The version of storage analytics to configure. Changing this forces a new resource. Default v1"
+  default     = "1.0"
+}
+
 variable "retention_policy_days" {
   type = number
   description = "Specifies the number of days that logs will be retained. Changing this forces a new resource. Default 7 days"
-  default = 7  
+  default = 10  
 }
 
 variable "resource_group_name" {

--- a/modules/storage/account/variables.tf
+++ b/modules/storage/account/variables.tf
@@ -46,30 +46,6 @@ variable "identity_ids" {
   default     = null
 }
 
-variable "queue_loging_delete" {
-  type        = bool
-  description = "Indicates whether all delete requests should be logged. Changing this forces a new resource. Default false"
-  default     = false
-}
-
-variable "queue_loging_read" {
-  type        = bool
-  description = "Indicates whether all read requests should be logged. Changing this forces a new resource. Default false"
-  default     = false
-}
-
-variable "queue_loging_write" {
-  type        = bool
-  description = "Indicates whether all write requests should be logged. Changing this forces a new resource. Default false"
-  default     = false
-}
-
-variable "queue_loging_version" {
-  type        = string
-  description = "The version of storage analytics to configure. Changing this forces a new resource. Default v1"
-  default     = "v1"
-}
-
 variable "retention_policy_days" {
   type = number
   description = "Specifies the number of days that logs will be retained. Changing this forces a new resource. Default 7 days"


### PR DESCRIPTION
# Remove queue properties from Storage Account template

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](./../CONTRIBUTING.md) and [Code of Conduct](./../CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

The logging policies retention were not being applied properly and hence it was causing a malformed XML making the sample not work (Storage Account and all the templates depending on it).

With this PR we lose lose the possibility to modify the logging properties, but this would work also if applied to any `BlobStorage` due to incompatibility as it stands in the documentation:

https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account#queue_properties

Fixes #25 